### PR TITLE
Remove node from the module name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Install the module with npm:
 
 ## Sample Usage
 
-    var ex = require('exiv2node');
+    var ex = require('exiv2');
 
     ex.getImageTags('./photo.jpg', function(err, tags) {
      if (err) {

--- a/exiv2node.cc
+++ b/exiv2node.cc
@@ -189,4 +189,4 @@ void InitAll(Handle<Object> target) {
   target->Set(String::NewSymbol("getImageTags"), FunctionTemplate::New(GetImageTags)->GetFunction());
   target->Set(String::NewSymbol("setImageTags"), FunctionTemplate::New(SetImageTags)->GetFunction());
 }
-NODE_MODULE(exiv2node, InitAll)
+NODE_MODULE(exiv2, InitAll)

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-var ex = require('exiv2node');
+var ex = require('exiv2');
 var assert = require('assert');
 var fs = require('fs')
 

--- a/wscript
+++ b/wscript
@@ -13,6 +13,6 @@ def configure(conf):
 def build(bld):
   obj = bld.new_task_gen("cxx", "shlib", "node_addon")
   obj.cxxflags = ["-g", "-D_FILE_OFFSET_BITS=64", "-D_LARGEFILE_SOURCE", "-Wall"]
-  obj.target = "exiv2node"
+  obj.target = "exiv2"
   obj.source = "exiv2node.cc"
   obj.uselib = "EXIV2"


### PR DESCRIPTION
I agree with the npm documentation's rationale:

```
This should be a string that identifies your project. Please do not
use the name to specify that it runs on node, or is in JavaScript.
You can use the "engines" field to explicitly state the versions of
node (or whatever else) that your program requires, and it's pretty
well assumed that it's javascript.

It does not necessarily need to match your github repository name.
```

  http://npmjs.org/doc/developers.html#The-package-json-File
