### PR TITLE
New api call: getImageMeta()

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ a package manager you might need to install an additional "-dev" packages.
 
 ### Debian
 
-    apt-get install libexiv2 libexiv2-dev
+    apt-get install exiv2 libexiv2-dev
 
 ### OS X
 
@@ -94,6 +94,25 @@ the tests:
         console.log("deleteImageTags complete..");
       }
     });
+
+### Meta Information:
+
+    var ex = require('exiv2')
+    ex.getImageMeta('./photo.jpg', function(err, meta){
+    if (err) {
+      console.error(err);
+    } else {
+      console.log("Meta:", meta);
+    }
+
+Meta information looks as follows:
+
+    { fileName: '/path/books.jpg',
+      fileSize: '993738',
+      mimeType: 'image/jpeg',
+      pixelHeight: '1200',
+      pixelWidth: '1600' }
+  
 
 Take a look at the `examples/` and `test/` directories for more.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "name": "exiv2",
   "description": "A native c++ extension for node.js that provides support for reading & writing image metadata via Exiv2.",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "homepage": "https://github.com/dberesford/exiv2node",
   "repository": {
     "type": "git",

--- a/test/test.js
+++ b/test/test.js
@@ -195,5 +195,19 @@ describe('exiv2', function(){
       var d = exiv.getDate(tags, 'Exif.Photo.DateTimeDigitized');
       d.toISOString().should.equal('2012-04-14T17:08:08.880Z');
     });
-  })
+  });
+
+  describe('.getMeta()', function(){
+    it("should callback with image's meta information", function(done) {
+      exiv.getImageMeta(dir + '/books.jpg', function(err, meta) {
+        should.not.exist(err);
+        meta.should.have.property('mimeType', 'image/jpeg');
+        meta.should.have.property('pixelHeight', '1200');
+        done();
+      })
+    });
+  });
+
+
+
 })


### PR DESCRIPTION
 Returns the following image properties (which are not tags but still very handy to have when processing images):

```
{ fileName: '/path/books.jpg',
  fileSize: '993738',
  mimeType: 'image/jpeg',
  pixelHeight: '1200',
  pixelWidth: '1600' }
```

Exiv2 also outputs these by default, along with the high level summary exif tags.
