### PR TITLE
Enabled setting of UTF8 characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .lock-wscript
+.project
 build/
 node_modules/
 test/copy.jpg

--- a/exiv2node.cc
+++ b/exiv2node.cc
@@ -211,8 +211,8 @@ static Handle<Value> SetImageTags(const Arguments& args) {
   for (unsigned i = 0; i < keys->Length(); i++) {
     Handle<v8::Value> key = keys->Get(i);
     thread_data->tags->insert(std::pair<std::string, std::string> (
-      *String::AsciiValue(key),
-      *String::AsciiValue(tags->Get(key)))
+      *String::Utf8Value(key),
+      *String::Utf8Value(tags->Get(key)))
     );
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -95,6 +95,58 @@ describe('exiv2', function(){
       });
     });
   });
+  
+  describe('.setUtf8ImageTags()', function(){
+      var temp = dir + '/copy.jpg';
+
+      before(function() {
+        fs.writeFileSync(temp, fs.readFileSync(dir + '/books.jpg'));
+      });
+      it('should write tags containing non-ascii characters to image files', function(done) {
+        var tags = {
+          "Exif.Photo.UserComment" : "Nogle bøger..",
+          "Exif.Canon.OwnerName" : "Sørens kamera",
+          "Iptc.Application2.RecordVersion" : "2",
+          "Xmp.dc.subject" : "ÅØÆ åøæ",
+          "Xmp.dc.rights": "lang=\"x-default\" © Åge Æble"
+        };
+        exiv.setImageTags(temp, tags, function(err){
+          should.not.exist(err);
+
+          exiv.getImageTags(temp, function(err, tags) {
+            tags.should.have.property('Exif.Photo.UserComment', "Nogle bøger..");
+            tags.should.have.property('Exif.Canon.OwnerName', "Sørens kamera");
+            tags.should.have.property('Iptc.Application2.RecordVersion', "2");
+            tags.should.have.property('Xmp.dc.subject', "ÅØÆ åøæ");
+            tags.should.have.property('Xmp.dc.rights', "lang=\"x-default\" © Åge Æble");
+            done();
+          });
+        });
+      })
+      after(function(done) {
+        fs.unlink(temp, done);
+      });
+
+      it('should throw if no file path is provided', function() {
+        (function(){
+          exiv.setImageTags()
+        }).should.throw();
+      });
+
+      it('should throw if no callback is provided', function() {
+        (function(){
+          exiv.setImageTags(dir + '/books.jpg')
+        }).should.throw();
+      });
+
+      it('should report an error on an invalid path', function(done) {
+        exiv.setImageTags('idontexist.jpg', {}, function(err, tags) {
+          should.exist(err);
+          should.not.exist(tags);
+          done();
+        });
+      });
+    });
 
   describe('.deleteImageTags()', function(){
     var temp = dir + '/copy-deltags.jpg';


### PR DESCRIPTION
Hi, and thanks for the exiv2node module, it's been very helpful.

This is a small fix which works for my use case, which required writing the copyright symbol and Danish characters to XMP.

Without the fix, the following error message appears if you attempt to write non-ascii characters (©, æ,å ,ø etc.) to XMP : "Error: XMP toolkit error 4: Invalid UTF-8 sequence length".
