### PR TITLE
Use NAN to support io.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - "0.6"
   - "0.8"
   - "0.10"
+  - "0.12"
+  - "iojs"
 before_install:
   - "sudo apt-get install libexiv2-dev"

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,6 +5,9 @@
       'sources': [
         'exiv2node.cc'
       ],
+      'include_dirs' : [
+          "<!(node -e \"require('nan')\")"
+      ],
       'xcode_settings': {
         'MACOSX_DEPLOYMENT_TARGET': '10.7',
         'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "name": "exiv2",
   "description": "A native c++ extension for node.js that provides support for reading & writing image metadata via Exiv2.",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "homepage": "https://github.com/dberesford/exiv2node",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "type": "git",
     "url": "git://github.com/dberesford/exiv2node.git"
   },
-  "dependencies": {},
+  "dependencies": {
+    "nan": ">= 1.7.0"
+  },
   "devDependencies": {
     "should": "*",
     "mocha": "*"


### PR DESCRIPTION
This should get things working with 0.12.x and [io.js](https://iojs.org/en/index.html). I went ahead and dropped support for 0.6. Too much had changed. I don't feel terrible since we're still supporting 0.8. 

Ended up refactoring most of our code to use the [`NanAsyncWorker`](https://github.com/rvagg/nan/#api_nan_async_worker). Had to touch quite a bit of it but it cleaned up a lot of stuff.