### PR TITLE
Fix the OS X build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -6,25 +6,20 @@
         'exiv2node.cc'
       ],
       'include_dirs' : [
-          "<!(node -e \"require('nan')\")"
+        '<!@(pkg-config --variable=includedir exiv2)',
+        "<!(node -e \"require('nan')\")"
       ],
       'xcode_settings': {
         'MACOSX_DEPLOYMENT_TARGET': '10.7',
         'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
         'OTHER_CPLUSPLUSFLAGS': ['-stdlib=libc++','-fcxx-exceptions', '-frtti'],
       },
-      'cflags': [
-        '<!@(pkg-config --cflags exiv2)'
-      ],
       'cflags_cc': [
         '-fexceptions'
       ],
       'libraries': [
         '<!@(pkg-config --libs exiv2)'
       ],
-      'ldflags': [
-        '<!@(pkg-config --libs exiv2)'
-      ]
     }
   ]
 }


### PR DESCRIPTION
The only thing that the `cflags` setting is being used for is passing in the includes. Those should technically go in the `include_dirs`. Moving these should fix the build issues some folks have been experiencing on El Capitan https://github.com/dberesford/exiv2node/issues/39.

While I was in here I noticed that what we've got `ldflags` duplicates what is already in `libraries` so I'm removing it.