### PR TITLE
Specify an a minimum npm version to get npm working on 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: node_js
 node_js:
   - "4.0"
-  - "0.12"
-  - "0.10"
-  - "0.8"
   - "iojs"
   - "iojs-v2"
   - "iojs-v1"
+  - "0.12"
+  - "0.10"
+  - "0.8"
 sudo: false
 addons:
   apt:
@@ -22,6 +22,6 @@ before_install:
             echo "Not upgrading npm for iojs."
             ;;
         *)
-            npm update -g npm
+            npm update -g npm@2.6.1
             ;;
     esac

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "optionalDependencies": {},
   "engines": {
-    "node": ">= 0.9.4"
+    "node": "~0.8.0"
   },
   "main": "exiv2",
   "scripts": {


### PR DESCRIPTION
On node 0.8.x we've been seeing this failure:

    Error: Cannot find module 'are-we-there-yet'