### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Exiv2
+# Exiv2
 
 Exiv2 is a native c++ extension for [io.js](https://iojs.org/en/index.html) and
 [node.js](https://nodejs.org/) that provides support for reading and writing


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
